### PR TITLE
Add fix for ios to enable passcode backup

### DIFF
--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -23,13 +23,25 @@ import LocalAuthentication
     var reason = "Authentication";
     let data  = command.arguments[0] as AnyObject?;
 
+    var policy:LAPolicy;
+    if #available(iOS 9.0, *) {
+        policy = .deviceOwnerAuthentication;
+    } else {
+        policy = .deviceOwnerAuthenticationWithBiometrics;
+    }
+    if let disableBackup = data?["disableBackup"] as! Bool? {
+        if disableBackup {
+            authenticationContext.localizedFallbackTitle = "";
+        }
+    }
+
     if let clientId = data?["clientId"] as! String? {
       reason = clientId;
     }
 
 
     authenticationContext.evaluatePolicy(
-      .deviceOwnerAuthenticationWithBiometrics,
+      policy,
       localizedReason: reason,
       reply: { [unowned self] (success, error) -> Void in
         if( success ) {

--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -23,22 +23,20 @@ import LocalAuthentication
     var reason = "Authentication";
     let data  = command.arguments[0] as AnyObject?;
 
-    var policy:LAPolicy;
-    if #available(iOS 9.0, *) {
-        policy = .deviceOwnerAuthentication;
-    } else {
-        policy = .deviceOwnerAuthenticationWithBiometrics;
-    }
-
+    var policy:LAPolicy = .deviceOwnerAuthenticationWithBiometrics;
     if let disableBackup = data?["disableBackup"] as! Bool? {
         if disableBackup {
             authenticationContext.localizedFallbackTitle = "";
             policy = .deviceOwnerAuthenticationWithBiometrics;
-        }
-    }
+        }else{
+          if let localizedFallbackTitle = data?["localizedFallbackTitle"] as! String? {
+            authenticationContext.localizedFallbackTitle = localizedFallbackTitle;
+          }
 
-    if let localizedFallbackTitle = data?["localizedFallbackTitle"] as! String? {
-      authenticationContext.localizedFallbackTitle = localizedFallbackTitle;
+          if #available(iOS 9.0, *) {
+              policy = .deviceOwnerAuthentication;
+          }
+      }
     }
 
     authenticationContext.evaluatePolicy(

--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -24,17 +24,16 @@ import LocalAuthentication
     let data  = command.arguments[0] as AnyObject?;
 
     var policy:LAPolicy = .deviceOwnerAuthenticationWithBiometrics;
+    if #available(iOS 9.0, *) {
+        policy = .deviceOwnerAuthentication;
+    }
     if let disableBackup = data?["disableBackup"] as! Bool? {
         if disableBackup {
             authenticationContext.localizedFallbackTitle = "";
             policy = .deviceOwnerAuthenticationWithBiometrics;
-        }else{
+        } else {
           if let localizedFallbackTitle = data?["localizedFallbackTitle"] as! String? {
             authenticationContext.localizedFallbackTitle = localizedFallbackTitle;
-          }
-
-          if #available(iOS 9.0, *) {
-              policy = .deviceOwnerAuthentication;
           }
       }
     }

--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -29,16 +29,17 @@ import LocalAuthentication
     } else {
         policy = .deviceOwnerAuthenticationWithBiometrics;
     }
+
     if let disableBackup = data?["disableBackup"] as! Bool? {
         if disableBackup {
             authenticationContext.localizedFallbackTitle = "";
+            policy = .deviceOwnerAuthenticationWithBiometrics;
         }
     }
 
-    if let clientId = data?["clientId"] as! String? {
-      reason = clientId;
+    if let localizedFallbackTitle = data?["localizedFallbackTitle"] as! String? {
+      authenticationContext.localizedFallbackTitle = localizedFallbackTitle;
     }
-
 
     authenticationContext.evaluatePolicy(
       policy,


### PR DESCRIPTION
Added fix for ios to enable users to enter the
passcode in case the finger print authentication
fails. Otherwise, Enter passcode button is present
but no action is present on clicking the same