### PR TITLE
adapt to swift 4 compiler

### DIFF
--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -3,7 +3,7 @@ import LocalAuthentication
 
 @objc(Fingerprint) class Fingerprint : CDVPlugin {
 
-  func isAvailable(_ command: CDVInvokedUrlCommand){
+  @objc func isAvailable(_ command: CDVInvokedUrlCommand){
     let authenticationContext = LAContext();
     var error:NSError?;
 
@@ -17,7 +17,7 @@ import LocalAuthentication
     commandDelegate.send(pluginResult, callbackId:command.callbackId);
   }
 
-  func authenticate(_ command: CDVInvokedUrlCommand){
+  @objc func authenticate(_ command: CDVInvokedUrlCommand){
     let authenticationContext = LAContext();
     var pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Something went wrong");
     var reason = "Authentication";


### PR DESCRIPTION
when not using the @objc keyword the swift 4 compiler creates another name mangling and the plugin functions are not found