### PR TITLE
Disbale passcode fallback on disableBackup

### DIFF
--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -30,6 +30,7 @@ import LocalAuthentication
     if let disableBackup = data?["disableBackup"] as! Bool? {
         if disableBackup {
             authenticationContext.localizedFallbackTitle = "";
+            policy = .deviceOwnerAuthenticationWithBiometrics;
         } else {
           if let localizedFallbackTitle = data?["localizedFallbackTitle"] as! String? {
             authenticationContext.localizedFallbackTitle = localizedFallbackTitle;


### PR DESCRIPTION
When disableBackup is true, on top of disabling
the "Enter Passcode" button on the failure touch
popup, prevent the fallback to passcode after
maximum retires with wrong touch as well.

close #51 