### PR TITLE
Fix collision of resouces identifier.

### DIFF
--- a/res/android/values-de/fpauth-strings.xml
+++ b/res/android/values-de/fpauth-strings.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License
   -->
 <resources>
-    <string name="cancel">Abbrechen</string>
-    <string name="use_backup">Passwort</string>
+    <string name="fingerprint_cancel">Abbrechen</string>
+    <string name="fingerprint_use_backup">Passwort</string>
     <string name="fingerprint_auth_dialog_title">Authentifizierung</string>
-    <string name="ok">OK</string>
+    <string name="fingerprint_ok">OK</string>
     <string name="fingerprint_description">Fingerabdruck bestätigen</string>
     <string name="fingerprint_hint">Fingerabdrucksensor</string>
     <string name="fingerprint_not_recognized">Fingerabdruck nicht erkannt. Versuchen Sie es erneut</string>

--- a/res/android/values-el/fpauth-strings.xml
+++ b/res/android/values-el/fpauth-strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="cancel">Ακύρωση</string>
-    <string name="use_backup">Χρήση αρχείου</string>
+    <string name="fingerprint_cancel">Ακύρωση</string>
+    <string name="fingerprint_use_backup">Χρήση αρχείου</string>
     <string name="fingerprint_auth_dialog_title">Ελεγχος αποτυπώματος</string>
-    <string name="ok">Ok</string>
+    <string name="fingerprint_ok">Ok</string>
     <string name="fingerprint_description">Επιβεβαίωση αποτυπώματος</string>
     <string name="fingerprint_hint">Αιθηστήρας αφής</string>
     <string name="fingerprint_not_recognized">Σφάλμα. Προσπαθήστε ξανά</string>

--- a/res/android/values-es/fpauth-strings.xml
+++ b/res/android/values-es/fpauth-strings.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License
   -->
 <resources>
-    <string name="cancel">Cancelar</string>
-    <string name="use_backup">El Respaldo</string>
+    <string name="fingerprint_cancel">Cancelar</string>
+    <string name="fingerprint_use_backup">El Respaldo</string>
     <string name="fingerprint_auth_dialog_title">Autenticación de Huellas Digitales</string>
-    <string name="ok">De Acuerdo</string>
+    <string name="fingerprint_ok">De Acuerdo</string>
     <string name="fingerprint_description">Confirmar la huella digital para continuar</string>
     <string name="fingerprint_hint">Sensor tactil</string>
     <string name="fingerprint_not_recognized">No se reconoce la huella digital. Inténtalo de nuevo.</string>

--- a/res/android/values-fr/fpauth-strings.xml
+++ b/res/android/values-fr/fpauth-strings.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License
   -->
 <resources>
-    <string name="cancel">Annuler</string>
-    <string name="use_backup">Utiliser la sauvegarde</string>
+    <string name="fingerprint_cancel">Annuler</string>
+    <string name="fingerprint_use_backup">Utiliser la sauvegarde</string>
     <string name="fingerprint_auth_dialog_title">Authentification par empreinte digitale</string>
-    <string name="ok">Ok</string>
+    <string name="fingerprint_ok">Ok</string>
     <string name="fingerprint_description">Confirmer l\'empreinte pour continuer</string>
     <string name="fingerprint_hint">Toucher le capteur</string>
     <string name="fingerprint_not_recognized">Empreinte non reconnue. Essayer à nouveau.</string>

--- a/res/android/values-it/fpauth-strings.xml
+++ b/res/android/values-it/fpauth-strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="cancel">Cancella</string>
-    <string name="use_backup">Usa backup</string>
+    <string name="fingerprint_cancel">Cancella</string>
+    <string name="fingerprint_use_backup">Usa backup</string>
     <string name="fingerprint_auth_dialog_title">Autenticazione impronta digitale</string>
-    <string name="ok">Ok</string>
+    <string name="fingerprint_ok">Ok</string>
     <string name="fingerprint_description">Conferma l\'impronta digitale per continuare</string>
     <string name="fingerprint_hint">Sensore Touch</string>
     <string name="fingerprint_not_recognized">Impronta digitale non riconosciuta. Riprova.</string>

--- a/res/android/values-pt/fpauth-strings.xml
+++ b/res/android/values-pt/fpauth-strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="cancel">Cancelar</string>
-    <string name="use_backup">Use o backup</string>
+    <string name="fingerprint_cancel">Cancelar</string>
+    <string name="fingerprint_use_backup">Use o backup</string>
     <string name="fingerprint_auth_dialog_title">Autenticação de impressão digital</string>
-    <string name="ok">Ok</string>
+    <string name="fingerprint_ok">Ok</string>
     <string name="fingerprint_description">Confirme a impressão digital para continuar</string>
     <string name="fingerprint_hint">Sensor de toque</string>
     <string name="fingerprint_not_recognized">impressão digital não reconhecida. Tente novamente.</string>

--- a/res/android/values-zh/fpauth-strings.xml
+++ b/res/android/values-zh/fpauth-strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="cancel">取消</string>
-  <string name="use_backup">使用手势密码</string>
+  <string name="fingerprint_cancel">取消</string>
+  <string name="fingerprint_use_backup">使用手势密码</string>
   <string name="fingerprint_auth_dialog_title">指纹识别</string>
-  <string name="ok">确认</string><string name="fingerprint_description">指纹识别</string>
+  <string name="fingerprint_ok">确认</string><string name="fingerprint_description">指纹识别</string>
   <string name="fingerprint_hint">请触摸指纹识传感器</string>
   <string name="fingerprint_not_recognized">指纹无法识别，请再试一次</string>
   <string name="fingerprint_success">指纹识别成功</string>

--- a/res/android/values/fpauth-strings.xml
+++ b/res/android/values/fpauth-strings.xml
@@ -15,10 +15,10 @@
   ~ limitations under the License
   -->
 <resources>
-    <string name="cancel">Cancel</string>
-    <string name="use_backup">Use backup</string>
+    <string name="fingerprint_cancel">Cancel</string>
+    <string name="fingerprint_use_backup">Use backup</string>
     <string name="fingerprint_auth_dialog_title">Fingerprint Authentication</string>
-    <string name="ok">Ok</string>
+    <string name="fingerprint_ok">Ok</string>
     <string name="fingerprint_description">Confirm fingerprint to continue</string>
     <string name="fingerprint_hint">Touch sensor</string>
     <string name="fingerprint_not_recognized">Fingerprint not recognized. Try again.</string>

--- a/src/android/FingerprintAuthenticationDialogFragment.java
+++ b/src/android/FingerprintAuthenticationDialogFragment.java
@@ -183,12 +183,12 @@ public class FingerprintAuthenticationDialogFragment extends DialogFragment
 
     private void updateStage() {
         int cancel_id = getResources()
-                .getIdentifier("cancel", "string", Fingerprint.packageName);
+                .getIdentifier("fingerprint_cancel", "string", Fingerprint.packageName);
         switch (mStage) {
             case FINGERPRINT:
                 mCancelButton.setText(cancel_id);
                 int use_backup_id = getResources()
-                        .getIdentifier("use_backup", "string", Fingerprint.packageName);
+                        .getIdentifier("fingerprint_use_backup", "string", Fingerprint.packageName);
                 mSecondDialogButton.setText(use_backup_id);
                 mFingerprintContent.setVisibility(View.VISIBLE);
                 break;


### PR DESCRIPTION
User fingerprint_ as prefix for cancel, use_backup and ok string resources.

@NiklasMerz we are using this plugin with the Mobile First 8 framework and we found name collisions for cancel and ok strings.