### PR TITLE
lock cordova to 7.0.1 for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
   fi
 - git clone https://github.com/apache/cordova-paramedic /tmp/paramedic && pushd /tmp/paramedic
   && npm install && popd
-- npm install -g cordova
+- npm install -g cordova@7.0.1
 install:
 - npm install
 script:


### PR DESCRIPTION
@NiklasMerz From the looks of it, I can't easily run these tests on my own travis profile, so I'm just making a PR so the tests will run. Taking a guess that a cordova update broke the tests last fall. Seems that Node 8.0 is still a bit of a second class citizen to them, they only just added it to the test matrix in December 2017: https://github.com/apache/cordova-lib/blob/master/RELEASENOTES.md#800-dec-14-2017