### PR TITLE
added objc anotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 package-lock.json
-.idea/

--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -4,7 +4,8 @@ import LocalAuthentication
 @objc(Fingerprint) class Fingerprint : CDVPlugin {
     
     fileprivate var policy:LAPolicy!
-    
+
+    @objc(isAvailable:)
     func isAvailable(_ command: CDVInvokedUrlCommand){
         let authenticationContext = LAContext();
         var biometryType = "finger";
@@ -30,7 +31,8 @@ import LocalAuthentication
         
         commandDelegate.send(pluginResult, callbackId:command.callbackId);
     }
-    
+
+    @objc(authenticate:)
     func authenticate(_ command: CDVInvokedUrlCommand){
         let authenticationContext = LAContext();
         var pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Something went wrong");


### PR DESCRIPTION
Hello, 
First, thanks for your great work!

I have a custom (not public) cordova plugin usign a the swift 4 version for iOS.
I was integrating your plugin in my app and realized about the @objc annotations. These are required on swift 4 for methods. Since my plugin is bigger and uses swift 4 I cannot change the version on my config.xml. 

I forked your plugin and added the anotiations for you to know. I don't think it will break anything to use the annotations and doing so your great plugin is compatible with Swift4.