### PR TITLE
#98 - fix return finger when no biometric available

### DIFF
--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -2,16 +2,20 @@ import Foundation
 import LocalAuthentication
 
 @objc(Fingerprint) class Fingerprint : CDVPlugin {
-    
+
     fileprivate var policy:LAPolicy!
-    
+
     func isAvailable(_ command: CDVInvokedUrlCommand){
         let authenticationContext = LAContext();
         var biometryType = "finger";
         var error:NSError?;
-        
+
         let available = authenticationContext.canEvaluatePolicy(policy, error: &error);
-        
+
+        if(error != nil && error?.code == LAError.touchIDNotAvailable.rawValue){
+            biometryType = "none";
+        }
+
         var pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Not available");
         if available == true {
             if #available(iOS 11.0, *) {
@@ -27,16 +31,16 @@ import LocalAuthentication
 
             pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: biometryType);
         }
-        
+
         commandDelegate.send(pluginResult, callbackId:command.callbackId);
     }
-    
+
     func authenticate(_ command: CDVInvokedUrlCommand){
         let authenticationContext = LAContext();
         var pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Something went wrong");
         var reason = "Authentication";
         let data  = command.arguments[0] as AnyObject?;
-        
+
         if let disableBackup = data?["disableBackup"] as! Bool? {
             if disableBackup {
                 authenticationContext.localizedFallbackTitle = "";
@@ -47,14 +51,14 @@ import LocalAuthentication
                 }
             }
         }
-        
+
         // Localized reason
         if let localizedReason = data?["localizedReason"] as! String? {
             reason = localizedReason;
         }else if let clientId = data?["clientId"] as! String? {
             reason = clientId;
         }
-        
+
         authenticationContext.evaluatePolicy(
             policy,
             localizedReason: reason,
@@ -70,16 +74,11 @@ import LocalAuthentication
                 self.commandDelegate.send(pluginResult, callbackId:command.callbackId);
         });
     }
-    
+
     override func pluginInitialize() {
         super.pluginInitialize()
-        
-        guard #available(iOS 9.0, *) else {
-            policy = .deviceOwnerAuthenticationWithBiometrics
-            return
-        }
-        
-        policy = .deviceOwnerAuthentication
+
+        policy = .deviceOwnerAuthenticationWithBiometrics
     }
 }
 


### PR DESCRIPTION

Concerning the bug #98 

I came up with the solution to check if biometric (TouchID) is available on older iOS versions.
This method _deviceOwnerAuthenticationWithBiometrics_  is used because it's more accurate to determine if Touch ID or Face ID is available, enrolled, and not disabled. [https://developer.apple.com/documentation/localauthentication/lapolicy/deviceownerauthentication](deviceownerauthentication) 