### PR TITLE
isAvailable method returns different error messages based upon the distinction between hardware being available on the device and no fingerprints being enrolled

### DIFF
--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -252,7 +252,12 @@ public class Fingerprint extends CordovaPlugin {
               mCallbackContext.success("finger");
             }else{
               mPluginResult = new PluginResult(PluginResult.Status.ERROR);
-              mCallbackContext.error("Fingerprint authentication not ready");
+
+              if (mFingerPrintManager.isHardwareDetected() && !mFingerPrintManager.hasEnrolledFingerprints()) {
+                mCallbackContext.error("Fingerprint authentication not ready");
+              } else {
+                mCallbackContext.error("Fingerprint authentication not available");
+              }
             }
             mCallbackContext.sendPluginResult(mPluginResult);
             return true;


### PR DESCRIPTION
isAvailable function has added error conditional check.

If fingerprint hardware is detected, but no fingerprints have been registered on the device, then the user is passed the error string "Fingerprint authentication not ready". Otherwise the user is passed the error string "Fingerprint authentication not available".

This is to allow the user to distinguish between these different scenarios. The presence of fingerprint hardware dictates a secure device. Also different UI flows and error reporting can be created based upon being able to make this distinction.

Applies to android only.

Fixes #130 