### PR TITLE
Remove deprecated error

### DIFF
--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -12,7 +12,7 @@ import LocalAuthentication
 
         let available = authenticationContext.canEvaluatePolicy(policy, error: &error);
 
-        if(error != nil && error?.code == LAError.touchIDNotAvailable.rawValue){
+        if(error != nil){
             biometryType = "none";
         }
 


### PR DESCRIPTION
close #137 

# Description
This error is deprecated since iOS 12. 

- [x] Test for all biomentrytypes
- [x] Local tests with iOS versions