### PR TITLE
[DEPENDENCY] Update cordova-plugin-add-swift-support to v2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/niklasmerz/cordova-plugin-fingerprint-aio#readme",
   "dependencies": {
-    "cordova-plugin-add-swift-support": "^1.7.1"
+    "cordova-plugin-add-swift-support": "^2.0.1"
   },
   "devDependencies": {
     "cordova-paramedic": "git+https://github.com/apache/cordova-paramedic.git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
 
   <!-- ios -->
   <platform name="ios">
-    <dependency id="cordova-plugin-add-swift-support" version="^1.7.1"/>
+    <dependency id="cordova-plugin-add-swift-support" version="^2.0.1"/>
     <config-file target="config.xml" parent="/*">
       <feature name="Fingerprint">
         <param name="ios-package" value="Fingerprint"/>


### PR DESCRIPTION
<!-- Thank you for contributing -->

# Description
Allows building in cordova 9. See: https://github.com/akofman/cordova-plugin-add-swift-support/issues/56

# How did you test your changes?
Force installed cordova-plugin-add-swift@2.0.1, and built successfully.