### PR TITLE
Fixed #158: Resources$NotFoundException thrown when the application is killed by OS

### DIFF
--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -433,4 +433,8 @@ public class Fingerprint extends CordovaPlugin {
         mPluginResult = new PluginResult(PluginResult.Status.ERROR);
         return false;
     }
+
+    public static boolean isPluginSetUp() {
+        return Fingerprint.packageName != null;
+    }
 }

--- a/src/android/FingerprintAuthenticationDialogFragment.java
+++ b/src/android/FingerprintAuthenticationDialogFragment.java
@@ -78,6 +78,12 @@ public class FingerprintAuthenticationDialogFragment extends DialogFragment
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+        if (!Fingerprint.isPluginSetUp()) {
+            Log.i(TAG, "Invalid state, view not created");
+            dismissAllowingStateLoss();
+            return null;
+        }
+
         Bundle args = getArguments();
         disableBackup = args.getBoolean("disableBackup");
         Log.d(TAG, "disableBackup: " + disableBackup);


### PR DESCRIPTION
# Description
This pull request is related to this issue: #158 

I have tried to be as less intrusive as possible with the fix so that I have just added a simple check which `dismiss` the fragment if the application was killed by the OS. To know if the OS killed the application, I just check if the application package name is set up because it must always be set up in order that the plugin works.

Feel free to discuss the change.

# How did you test your changes?
I tested the fix on Samsung Galaxy J6 which has Fingerprint ID.