### PR TITLE
Propagating iOS sensor recognition error

### DIFF
--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -16,7 +16,7 @@ import LocalAuthentication
             biometryType = "none";
         }
 
-        var pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Error: \(String(describing: error?.localizedDescription))");
+        var pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "\(String(describing: error?.localizedDescription))");
         if available == true {
             if #available(iOS 11.0, *) {
                 switch(authenticationContext.biometryType) {

--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -16,7 +16,7 @@ import LocalAuthentication
             biometryType = "none";
         }
 
-        var pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Not available");
+        var pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Error: \(String(describing: error?.localizedDescription))");
         if available == true {
             if #available(iOS 11.0, *) {
                 switch(authenticationContext.biometryType) {


### PR DESCRIPTION
In Fingerprint.swift: it is more useful to have the error text returned by iOS, than a generic "Not available" error.
iOS devices usually return messages like:
- "Biometry is not available on this device."
- "No identities are enrolled."
It is useful to know if the sensor not supported at all, or if the user haven't enrolled any fingerprints/face.