### PR TITLE
#151: Attempt to invoke virtual method 'boolean android.hardware.fing…

### DIFF
--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -252,7 +252,7 @@ public class Fingerprint extends CordovaPlugin {
                 mCallbackContext.sendPluginResult(mPluginResult);
             }
             return true;
-        } else if (action.equals("isAvailable")) {
+        } else if (action.equals("isAvailable") && null != mFingerPrintManager) {
             if(mFingerPrintManager.isHardwareDetected() && mFingerPrintManager.hasEnrolledFingerprints()){
                 mPluginResult = new PluginResult(PluginResult.Status.OK, "finger");
                 mCallbackContext.success("finger");
@@ -272,7 +272,8 @@ public class Fingerprint extends CordovaPlugin {
     }
 
     private boolean isFingerprintAuthAvailable() {
-        return mFingerPrintManager.isHardwareDetected()
+        return null != mFingerPrintManager
+                && mFingerPrintManager.isHardwareDetected()
                 && mFingerPrintManager.hasEnrolledFingerprints();
     }
 


### PR DESCRIPTION
…erprint.FingerprintManager.isHardwareDetected()' on a null object reference

- Added null check at every place where mFingerPrintManager used to prevent "boolean android.hardware.fingerprint.FingerprintManager.isHardwareDetected()' on a null object reference"

<!-- Thank you for contributing -->

# Description

Hey guys. Yesterday I testing my app on Xiaomi Redmi 6A and met next exception:

`
E/PluginManager: Uncaught exception from pluginjava.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.hardware.fingerprint.FingerprintManager.isHardwareDetected()' on a null object referenceat de.niklasmerz.cordova.fingerprint.Fingerprint.execute(Fingerprint.java:256)at org.apache.cordova.CordovaPlugin.execute(CordovaPlugin.java:98)at org.apache.cordova.PluginManager.exec(PluginManager.java:132)at com.getcapacitor.MessageHandler.callCordovaPluginMethod(MessageHandler.java:70)at com.getcapacitor.MessageHandler.postMessage(MessageHandler.java:46)at android.os.MessageQueue.nativePollOnce(Native Method)at android.os.MessageQueue.next(MessageQueue.java:331)at android.os.Looper.loop(Looper.java:149)at android.os.HandlerThread.run(HandlerThread.java:65)
`

Currently, I want to use your plugin in next release of my app but it's unstable on some devices. Please review PR and bump new patch. Many thanks.