### PR TITLE
Make error response final

### DIFF
--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -157,7 +157,7 @@ public class Fingerprint extends CordovaPlugin {
                            CallbackContext callbackContext) throws JSONException {
         mCallbackContext = callbackContext;
         Log.v(TAG, "Fingerprint action: " + action);
-        JSONObject errorResponse = new JSONObject();
+        final JSONObject errorResponse = new JSONObject();
 
         if (android.os.Build.VERSION.SDK_INT < 23) {
             Log.e(TAG, "minimum SDK version 23 required");


### PR DESCRIPTION
Fixes: Fingerprint.java:234: error: local variable errorResponse is accessed from within inner class; needs to be declared final

<!-- Thank you for contributing -->

# Description

Prevent compile issues by making errorResponse final

# How did you test your changes?

Compiled locally, no issues