### PR TITLE
iOS only: Fixed isAvailable to return error code rather than generic …

### DIFF
--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -33,8 +33,6 @@ import LocalAuthentication
         var pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Not available");
         let available = authenticationContext.canEvaluatePolicy(policy, error: &error);
 
-        var results: [String : Any]
-
         if(error != nil){
             biometryType = "none";
             errorResponse["code"] = error?.code;
@@ -55,31 +53,45 @@ import LocalAuthentication
 
             pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: biometryType);
         }else{
-            var code: Int;
-            switch(error!._code) {
-                case Int(kLAErrorBiometryNotAvailable):
-                    code = PluginError.BIOMETRIC_UNAVAILABLE.rawValue;
-                    break;
-                case Int(kLAErrorBiometryNotEnrolled):
-                    code = PluginError.BIOMETRIC_NOT_ENROLLED.rawValue;
-                    break;
-
-                default:
-                    code = PluginError.BIOMETRIC_UNKNOWN_ERROR.rawValue;
-                    break;
-            }
-            results = ["code": code, "message": error!.localizedDescription];
-            pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: results);
+            pluginResult = self.handleError(error: error);
         }
 
         commandDelegate.send(pluginResult, callbackId:command.callbackId);
+    }
+
+    @objc(handleError:)
+    func handleError(error: Error?) -> CDVPluginResult? {
+        let errorResponse: [AnyHashable: Any] = [
+            "message": "Something went wrong"
+        ];
+        var pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: errorResponse);
+        if (error != nil) {
+
+            var errorCodes = [Int: ErrorCodes]()
+            var errorResult: [String : Any] = ["code":  PluginError.BIOMETRIC_UNKNOWN_ERROR.rawValue, "message": error?.localizedDescription ?? ""];
+
+            errorCodes[1] = ErrorCodes(code: PluginError.BIOMETRIC_AUTHENTICATION_FAILED.rawValue)
+            errorCodes[2] = ErrorCodes(code: PluginError.BIOMETRIC_DISMISSED.rawValue)
+            errorCodes[5] = ErrorCodes(code: PluginError.BIOMETRIC_SCREEN_GUARD_UNSECURED.rawValue)
+            errorCodes[6] = ErrorCodes(code: PluginError.BIOMETRIC_UNAVAILABLE.rawValue)
+            errorCodes[7] = ErrorCodes(code: PluginError.BIOMETRIC_NOT_ENROLLED.rawValue)
+            errorCodes[8] = ErrorCodes(code: PluginError.BIOMETRIC_LOCKED_OUT.rawValue)
+
+            let errorCode = abs(error!._code)
+            if let e = errorCodes[errorCode] {
+               errorResult = ["code": e.code, "message": error!.localizedDescription];
+            }
+
+            pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: errorResult);
+        }
+        return pluginResult;
     }
 
 
     @objc(authenticate:)
     func authenticate(_ command: CDVInvokedUrlCommand){
         let authenticationContext = LAContext();
-        var errorResponse: [AnyHashable: Any] = [
+        let errorResponse: [AnyHashable: Any] = [
             "message": "Something went wrong"
         ];
         var pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: errorResponse);
@@ -112,25 +124,7 @@ import LocalAuthentication
                 if( success ) {
                     pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: "Success");
                 }else {
-                    if (error != nil) {
-
-                        var errorCodes = [Int: ErrorCodes]()
-                        var errorResult: [String : Any] = ["code":  PluginError.BIOMETRIC_UNKNOWN_ERROR.rawValue, "message": error?.localizedDescription ?? ""];
-
-                        errorCodes[1] = ErrorCodes(code: PluginError.BIOMETRIC_AUTHENTICATION_FAILED.rawValue)
-                        errorCodes[2] = ErrorCodes(code: PluginError.BIOMETRIC_DISMISSED.rawValue)
-                        errorCodes[5] = ErrorCodes(code: PluginError.BIOMETRIC_SCREEN_GUARD_UNSECURED.rawValue)
-                        errorCodes[6] = ErrorCodes(code: PluginError.BIOMETRIC_UNAVAILABLE.rawValue)
-                        errorCodes[7] = ErrorCodes(code: PluginError.BIOMETRIC_NOT_ENROLLED.rawValue)
-                        errorCodes[8] = ErrorCodes(code: PluginError.BIOMETRIC_LOCKED_OUT.rawValue)
-
-                        let errorCode = abs(error!._code)
-                        if let e = errorCodes[errorCode] {
-                           errorResult = ["code": e.code, "message": error!.localizedDescription];
-                        }
-
-                        pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: errorResult);
-                    }
+                    pluginResult = self.handleError(error: error);
                 }
                 self.commandDelegate.send(pluginResult, callbackId:command.callbackId);
             }


### PR DESCRIPTION
<!-- Thank you for contributing -->

# Description
Fixed #226 , where isAvailable function in iOS returns generic error rather than specific error

# How did you test your changes?
Tested the changes on my personal application.
I tried to run test-ios, but seems like some issue with my simulator which is throwing error to run the app. However when I tested with my production application, it works perfectly.