### PR TITLE
Fixed "ambiguous user of subscript(_:)" compile error.

### DIFF
--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -85,7 +85,7 @@ import LocalAuthentication
         var pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: errorResponse);
         var reason = "Authentication";
         var policy:LAPolicy = .deviceOwnerAuthentication;
-        let data  = command.arguments[0] as AnyObject?;
+        let data  = command.arguments[0] as? [String: Any];
 
         if let disableBackup = data?["disableBackup"] as! Bool? {
             if disableBackup {


### PR DESCRIPTION
Fingerprint.swift suddenly stopped compiling as described here: https://github.com/NiklasMerz/cordova-plugin-fingerprint-aio/issues/201

Added a conditional type cast to a dictionary to fix compile error.