### PR TITLE
add optional 'allowBackup' parameter to isAvailable() #175

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cordova plugin add https://github.com/NiklasMerz/cordova-plugin-fingerprint-aio.
 
 ### Check if fingerprint authentication is available
 ```javascript
-Fingerprint.isAvailable(isAvailableSuccess, isAvailableError);
+Fingerprint.isAvailable(isAvailableSuccess, isAvailableError, optionalParams);
 
     function isAvailableSuccess(result) {
       /*
@@ -87,6 +87,9 @@ Fingerprint.isAvailable(isAvailableSuccess, isAvailableError);
       alert(error.message);
     }
 ```
+### Optional parameters
+
+* __allowBackup (iOS)__: If `true` checks if backup authentication option is available, e.g. passcode. Default: `false`, which means check for biometrics only.
 
 ### Show authentication dialogue
 ```javascript

--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -29,7 +29,9 @@ import LocalAuthentication
             "message": "Not Available"
         ];
         var error:NSError?;
-        let policy:LAPolicy = .deviceOwnerAuthenticationWithBiometrics;
+        let params = command.argument(at: 0) as? [AnyHashable: Any] ?? [:]
+        let allowBackup = params["allowBackup"] as? Bool ?? false
+        let policy:LAPolicy = allowBackup ? .deviceOwnerAuthentication : .deviceOwnerAuthenticationWithBiometrics;
         var pluginResult = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: "Not available");
         let available = authenticationContext.canEvaluatePolicy(policy, error: &error);
 

--- a/www/Fingerprint.js
+++ b/www/Fingerprint.js
@@ -33,13 +33,17 @@ Fingerprint.prototype.show = function (params, successCallback, errorCallback) {
   );
 };
 
-Fingerprint.prototype.isAvailable = function (successCallback, errorCallback) {
+Fingerprint.prototype.isAvailable = function (arg0, arg1, arg2) {
+  const hasParams = typeof arg0 === 'object';
+  const params = hasParams ? arg0 : {};
+  const successCallback = hasParams ? arg1 : arg0;
+  const errorCallback = hasParams ? arg2 : arg1;
   cordova.exec(
     successCallback,
     errorCallback,
     "Fingerprint",
     "isAvailable",
-    [{}]
+    [params]
   );
 };
 


### PR DESCRIPTION
<!-- Thank you for contributing -->

# Description

This PR closes #175 

# How did you test your changes?

1. Checked that `isAvailable({ allowBackup: true })` works correctly with passcode only enabled on device (e.g. when all touchID/faceID identities removed from device settings).
2. Checked that `isAvailable()` called without params behaves the same as before so no breaking changes were made.
