### PR TITLE
Docs/swift version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 * Android - Minimum SDK 23
 * iOS - **XCode 9.2 or higher** required
-  * _Please set `<preference name="UseSwiftLanguageVersion" value="4.0" />` in your config.xml_
+  * _Please set `<preference name="SwiftVersion" value="4.0" />` in your config.xml_
 
 
 ## How to use

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 * Android - Minimum SDK 23
 * iOS - **XCode 9.2 or higher** required
-  * _Please set `<preference name="SwiftVersion" value="4.0" />` in your config.xml_
+  * _Please set `<preference name="UseSwiftLanguageVersion" value="4.0" />` in your config.xml_
 
 
 ## How to use


### PR DESCRIPTION
<!-- Thank you for contributing -->

# Description

The correct name for setting `SWIFT_VERSION` is `SwiftVersion`. When UseSwiftLanguageVersion is used, the result is
`error: Value for SWIFT_VERSION cannot be empty.`

# How it was tested

By creating a project using `cordova-plugin-fingerprint-aio`, reproducing the error, then running with the correction.