### PR TITLE
android: handle onAuthenticationFailed

### DIFF
--- a/src/android/BiometricActivity.java
+++ b/src/android/BiometricActivity.java
@@ -125,6 +125,7 @@ public class BiometricActivity extends AppCompatActivity {
                 @Override
                 public void onAuthenticationFailed() {
                     super.onAuthenticationFailed();
+                    onError(PluginError.BIOMETRIC_AUTHENTICATION_FAILED.getValue(), PluginError.BIOMETRIC_AUTHENTICATION_FAILED.getMessage());
                 }
             };
 


### PR DESCRIPTION
The `onAuthenticationFailed` method was not implemented to do something. This seems to be no problem on many devices since the biometric prompt allows a retry and just calls `onAuthenticationError` after too many failed attempts. This is the case on the emulator for example.

OnePlus chose to implement this differently (on the 6T at least) for some reason. The biometric prompt does not have a UI and after a failed attempt seems to be stuck until you press cancel. This fixes that by implementing the method and calling the error callback back to Cordova.

Closes #247
