### PR TITLE
Fix User Disabled Security Pattern Flow

### DIFF
--- a/src/android/EncryptedData.java
+++ b/src/android/EncryptedData.java
@@ -31,11 +31,22 @@ class EncryptedData {
         save(CIPHERTEXT_KEY_NAME, ciphertext, context);
     }
 
+    static void remove(Context context) {
+        remove(IV_KEY_NAME, context);
+        remove(CIPHERTEXT_KEY_NAME, context);
+    }
+
     private void save(String key, byte[] value, Context context) {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-        preferences.edit()
-                .putString(key, Base64.encodeToString(value, Base64.DEFAULT))
-                .apply();
+        preferences.edit().putString(key, Base64.encodeToString(value, Base64.DEFAULT)).apply();
+    }
+
+    private static void remove(String key, Context context) {
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        String res = preferences.getString(key, null);
+        if(res != null){
+            preferences.edit().remove(key).apply();
+        }
     }
 
     private static byte[] load(String key, Context context) throws CryptoException {


### PR DESCRIPTION
<!-- Thank you for contributing -->

# Description
The plugin can't recover when user disable security pattern and try to load a new secret, the method KeyStore.getKey throw an exception and says "user changed or deleted their auth credentials", it was added a method to also remove ciphertext and IV initializationVector from app storage in order to show the message BIOMETRIC_NO_SECRET_FOUND and manage exceptions to deleteKey and storage keys from app

# How did you test your changes?
I tested on a Pixel 4 emulator and also in a SM-N9600 Samsung Note 9