### PR TITLE
fix java.lang.NullPointerException

### DIFF
--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -157,8 +157,12 @@ public class Fingerprint extends CordovaPlugin {
 
             PluginResult result = new PluginResult(PluginResult.Status.ERROR, resultJson);
             result.setKeepCallback(true);
-            cordova.getActivity().runOnUiThread(() ->
-                    Fingerprint.this.mCallbackContext.sendPluginResult(result));
+            if (cordova.getActivity() != null) {
+                cordova.getActivity().runOnUiThread(() ->
+                        this.mCallbackContext.sendPluginResult(result));
+            } else {
+                Log.e(TAG, "Cordova activity does not exist.");
+            }
         } catch (JSONException e) {
             Log.e(TAG, e.getMessage(), e);
         }


### PR DESCRIPTION
<!-- Thank you for contributing -->

# Description

We had a lot of errors on Google Play Console with the following error:

```
Exception java.lang.RuntimeException:
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:5378)
  at android.app.ActivityThread.handleResumeActivity (ActivityThread.java:5444)
  at android.app.servertransaction.ResumeActivityItem.execute (ResumeActivityItem.java:54)
  at android.app.servertransaction.ActivityTransactionItem.execute (ActivityTransactionItem.java:45)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleState (TransactionExecutor.java:176)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:97)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2574)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8757)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:571)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1067)
Caused by java.lang.RuntimeException:
  at android.app.ActivityThread.deliverResults (ActivityThread.java:5994)
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:5348)
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'void org.apache.cordova.CallbackContext.sendPluginResult(org.apache.cordova.PluginResult)' on a null object reference
  at de.niklasmerz.cordova.biometric.Fingerprint.lambda$sendError$1 (Fingerprint.java)
  at android.app.Activity.runOnUiThread (Activity.java:7494)
  at de.niklasmerz.cordova.biometric.Fingerprint.sendError (Fingerprint.java:161)
  at de.niklasmerz.cordova.biometric.Fingerprint.sendError (Fingerprint.java:132)
  at de.niklasmerz.cordova.biometric.Fingerprint.onActivityResult (Fingerprint.java:115)
  at org.apache.cordova.CordovaInterfaceImpl.onActivityResult (CordovaInterfaceImpl.java:160)
  at org.apache.cordova.CordovaActivity.onActivityResult (CordovaActivity.java:375)
  at android.app.Activity.dispatchActivityResult (Activity.java:8951)
  at android.app.ActivityThread.deliverResults (ActivityThread.java:5987)
```
This seems to happen only on certain devices.

This PR checks if the activity still exists to send the result back to cordova.

# How did you test your changes?

We deployed our app in beta and the errors no longer appear and have no negative impact for users.