### PR TITLE
Added new option to isAvailable - requireStrongBiometrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Fingerprint.isAvailable(isAvailableSuccess, isAvailableError, optionalParams);
 ### Optional parameters
 
 * __allowBackup (iOS)__: If `true` checks if backup authentication option is available, e.g. passcode. Default: `false`, which means check for biometrics only.
+* __requireStrongBiometrics (Android)__: If `true` will only return success if Class 3 (BIOMETRIC_STRONG) Biometrics are enrolled on the device. It is reccomended you use this if planning on using the `registerBiometricSecret` and `loadBiometricSecret` methods.
 
 ### Show authentication dialogue
 ```javascript


### PR DESCRIPTION
<!-- Thank you for contributing -->

# Description
Added a new option to `isAvailable()` - `requireStrongBiometrics`. When `true`, backend calls to `BiometricManager.canAuthenticate()` will specify strong biometrics only. This should fix the underlying issue behind #473.

# How did you test your changes?
Tested on Android Samsung Galaxy S22. Confirmed that `isAvailable(successFN, errorFN, { requireStrongBiometrics: true })` fails when the device has only a face ID (weak) registered and passes when a device has one or more fingerprints (strong) registered.